### PR TITLE
feat: access job data from within workflow (#CL-839)

### DIFF
--- a/src/askui_runner/__main__.py
+++ b/src/askui_runner/__main__.py
@@ -50,6 +50,7 @@ def build_runner_core_config(config: Config):
             api_url=runner_job_data.results_api_url,
             dir=config.runner.results_dir,
         ),
+        data=runner_job_data.data,
     )
 
 

--- a/src/askui_runner/modules/core/infrastructure/runner/askui.py
+++ b/src/askui_runner/modules/core/infrastructure/runner/askui.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import shutil
@@ -94,6 +95,8 @@ class AskUiJestRunnerService(Runner):
         os.system("npm install")
         copy_directory_contents(src_dir=self.project_dir, dest_dir=dir_path)
         self.render_templates(dir_path=dir_path)
+        with create_and_open(os.path.join(dir_path, "data.json"), "w") as f:
+            json.dump(self.config.data, f)
         os.chdir(dir_path)
 
     def run_workflows(self) -> RunWorkflowsResult:

--- a/src/askui_runner/modules/core/models.py
+++ b/src/askui_runner/modules/core/models.py
@@ -1,3 +1,4 @@
+from typing import Any
 from pydantic import BaseModel, BaseSettings, Field
 
 
@@ -50,6 +51,7 @@ class CoreConfig(CoreConfigBase, BaseSettings):
     inference_api_url: str
     workflows: WorkflowsConfig
     results: ResultsConfig
+    data: dict[str, Any] = Field(default_factory=dict)
     
     class Config:
         env_prefix = "askui_runner_core_"

--- a/src/askui_runner/modules/queue/models.py
+++ b/src/askui_runner/modules/queue/models.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, BaseSettings, Field, validator
@@ -123,6 +123,21 @@ class RunnerJobData(BaseModel):
     results_api_url: str  # TODO Depending on feature toggle you don't need to provide all of these with job config
     workflows_api_url: str
     inference_api_url: str
+    data: dict[str, Any] = Field(default_factory=dict)
+    
+    def dict(self, **kwargs) -> dict[str, Any]:
+        if "exclude" in kwargs and kwargs["exclude"] is not None:
+            if "data" not in kwargs["exclude"]:
+                if isinstance(kwargs["exclude"], set):
+                    kwargs["exclude"] |= {"data"}
+                else:
+                    kwargs["exclude"] |= {"data": True}
+        else:
+            kwargs["exclude"] = {"data"}
+        return {
+            **super().dict(**kwargs),
+            "data": self.data,
+        }
 
 
 class LogLevel(str, enum.Enum):
@@ -208,3 +223,5 @@ class Config(
             keep_alive=self.queue.keep_alive if self.queue else False,
             polling_interval=self.queue.polling_interval if self.queue else 30,
         )
+
+# TODO Does K8s still work?

--- a/src/askui_runner/project_template/helper/jest.setup.ts.jinja
+++ b/src/askui_runner/project_template/helper/jest.setup.ts.jinja
@@ -1,6 +1,7 @@
 import { UiControlClient } from 'askui';
 import { AskUIAllureStepReporter } from '@askui/askui-reporters';
 import {Blob} from 'node:buffer';
+import data from '@/data.json';
 
 let aui: UiControlClient;
 
@@ -50,4 +51,4 @@ afterAll(async () => {
   aui.disconnect();
 });
 
-export { aui };
+export { aui, data };

--- a/src/askui_runner/project_template/tsconfig.json
+++ b/src/askui_runner/project_template/tsconfig.json
@@ -7,5 +7,6 @@
             ]
         },
         "esModuleInterop": true,
+        "resolveJsonModule": true
     }
 }


### PR DESCRIPTION
Allows accessing data saved with the schedule (runs and jobs) in the following manner:
```typescript
      import { aui, data } from "@/helper/jest.setup";

      it("test-data.ts", async () => {
        console.log(data)
        await aui.click().text(data["text"]).exec()
      });
```