### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askui-runner"
-version = "0.2.6"
+version = "0.2.7"
 description = "Runner for Workflows Defined in AskUI Studio"
 dependencies = [
     "dependency-injector>=4.44.0",


### PR DESCRIPTION
NB: Release 0.2.7 needs to be recreated.